### PR TITLE
Live example for minimum component declaration

### DIFF
--- a/docs/0.7/Components.md.hbs
+++ b/docs/0.7/Components.md.hbs
@@ -12,6 +12,10 @@ First, you need to **create the component** with {{{createLink 'Ractive.extend()
 * [The \{{yield}} Directive](#yield)
 * [Parents and Containers](#parent)
 
+## Minumum example
+
+<script async src="//jsfiddle.net/ceremcem/akhc6by6/embed/"></script>
+
 ## <a name="init"></a>Initialisation Options
 
 Most of the normal Ractive {{{ createLink 'options' 'initialisation options' }}} also apply to components, particularly the {{{ createLink 'lifecycle events' }}}, a few of which are listed here.


### PR DESCRIPTION
Live example is added for minimum component declaration, regarding to https://github.com/ractivejs/docs.ractivejs.org/issues/261

**NOTE**: The added line is not tested 